### PR TITLE
feature/add-organization-search

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,10 +1,16 @@
 class OrganizationsController < ApplicationController
   before_action :authorize
+
   def index
-    @organizations = Organization.all
+    @search_name = params[:name]
+    @organizations = Organization.order(:name)
+    @organizations = @organizations.search_by_name(@search_name) if @search_name.present?
   end
 
   def show
     @organization = Organization.find(params[:id])
   end
+
+  private
+
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,5 @@
 class Organization < ApplicationRecord
   validates :name, presence: true
+
+  scope :search_by_name, -> (name) { where("lower(name) LIKE ?", "%#{name}%") }
 end

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,3 +1,11 @@
 <% provide(:title, "All Organizations") %>
 
+<%= form_with url: organizations_path, skip_enforcing_utf8: true, method: :get, local: true do |f| %>
+  <%= f.label :name, "Find Organization" %>
+  <%= f.text_field :name, id: :name, value: params[:name], autofocus: true %>
+  <%= f.submit "Search", name: nil %>
+<% end %>
+
+<%= button_to "View All", organizations_path, method: :get %>
+
 <%= render @organizations %>

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -12,4 +12,32 @@ RSpec.describe Organization, type: :model do
 
     expect(organization.errors[:name]).to include("can't be blank")
   end
+
+  context "Searching" do
+    let!(:organization_1) { FactoryBot.create(:organization, name: "Test LLC Org") }
+    let!(:organization_2) { FactoryBot.create(:organization, name: "Potato Org") }
+    let!(:organization_3) { FactoryBot.create(:organization, name: "An LLC Organization") }
+    let!(:organization_4) { FactoryBot.create(:organization, name: "The Office") }
+    let!(:organization_5) { FactoryBot.create(:organization, name: "Wellness Organization") }
+
+    it "returns all organizations on empty search" do
+      filtered = Organization.search_by_name("").count
+      expect(filtered).to eq Organization.count
+    end
+
+    it "returns expected number of organizations when matching results found" do
+      filtered = Organization.search_by_name("LL").count
+      expect(filtered).to eq 3
+    end
+
+    it "returns expected number organizations with lowercase input" do
+      filtered = Organization.search_by_name("ll").count
+      expect(filtered).to eq 3
+    end
+
+    it "returns expected number organizations with mixed case input" do
+      filtered = Organization.search_by_name("lL").count
+      expect(filtered).to eq 3
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe Organization, type: :model do
   end
 
   context "Searching" do
-    let!(:organization_1) { FactoryBot.create(:organization, name: "Test LLC Org") }
-    let!(:organization_2) { FactoryBot.create(:organization, name: "Potato Org") }
-    let!(:organization_3) { FactoryBot.create(:organization, name: "An LLC Organization") }
-    let!(:organization_4) { FactoryBot.create(:organization, name: "The Office") }
-    let!(:organization_5) { FactoryBot.create(:organization, name: "Wellness Organization") }
+    let!(:organization_1) { FactoryBot.create(:organization, name: "Test LLC Org", id: 1) }
+    let!(:organization_2) { FactoryBot.create(:organization, name: "Potato Org", id: 2) }
+    let!(:organization_3) { FactoryBot.create(:organization, name: "An LLC Organization", id: 3) }
+    let!(:organization_4) { FactoryBot.create(:organization, name: "The Office", id: 4) }
+    let!(:organization_5) { FactoryBot.create(:organization, name: "Swell Corgis", id: 5) }
+    let(:organizations) { Organization.order(:name) }
 
     it "returns all organizations on empty search" do
       filtered = Organization.search_by_name("").count
@@ -38,6 +39,16 @@ RSpec.describe Organization, type: :model do
     it "returns expected number organizations with mixed case input" do
       filtered = Organization.search_by_name("lL").count
       expect(filtered).to eq 3
+    end
+
+    it "returns expected organizations in alphabetical order" do
+      names_and_ids = organizations.search_by_name("org").pluck(:name, :id)
+      expect(names_and_ids).to eq [
+        ["An LLC Organization", 3],
+        ["Potato Org", 2],
+        ["Swell Corgis", 5],
+        ["Test LLC Org", 1]
+      ]
     end
   end
 end


### PR DESCRIPTION
Add search functionality to Organizations via scoping.

Search Form:
As noted in the commit for the search form (c1c108b7188080177376195cb606941589e9c69d), I added options to the form that clean up the URL after search to a much more readable format.

Final URL prior to options:
http://localhost:3000/organizations?utf8=%E2%9C%93&name=llc&commit=Search

After options:
http://localhost:3000/organizations?name=llc