### PR TITLE
feature/add-memberships

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,4 @@
+class Membership < ApplicationRecord
+  belongs_to :organization
+  belongs_to :user
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,10 @@
 class Membership < ApplicationRecord
   belongs_to :organization
   belongs_to :user
+
+  validates :organization_id,
+            uniqueness: {
+              scope: :user_id,
+              message: "already has a membership with this user."
+            }
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,7 @@
 class Organization < ApplicationRecord
+  has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
+
   validates :name, presence: true
 
   scope :search_by_name, -> (name) { where("lower(name) LIKE ?", "%#{name}%") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   has_secure_password
 
+  has_many :memberships, dependent: :destroy
+  has_many :organizations, through: :memberships
+
   validates :first_name, :last_name, :email, presence: true
   validates :email, uniqueness: true
 end

--- a/db/migrate/20200902013742_create_memberships.rb
+++ b/db/migrate/20200902013742_create_memberships.rb
@@ -1,0 +1,8 @@
+class CreateMemberships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :memberships do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :organization, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/migrate/20200903022950_add_unique_index_to_memberships.rb
+++ b/db/migrate/20200903022950_add_unique_index_to_memberships.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMemberships < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:memberships, [:organization_id, :user_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_013742) do
+ActiveRecord::Schema.define(version: 2020_09_03_022950) do
 
   create_table "memberships", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "organization_id", null: false
+    t.index ["organization_id", "user_id"], name: "index_memberships_on_organization_id_and_user_id", unique: true
     t.index ["organization_id"], name: "index_memberships_on_organization_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_07_160951) do
+ActiveRecord::Schema.define(version: 2020_09_02_013742) do
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "organization_id", null: false
+    t.index ["organization_id"], name: "index_memberships_on_organization_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
 
   create_table "organizations", force: :cascade do |t|
     t.string "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,14 @@ def random_password
   rand(100000...900000).to_s
 end
 
+def random_org_id
+  Organization.all.sample.id
+end
+
+def random_user_id
+  User.all.sample.id
+end
+
 user_seeds = [
   {first_name: "Dev", last_name: "Challenger", email: "dev@dundermifflin.com", password: "password1234", password_confirmation: "password1234"},
   {first_name: "Jim", last_name: "Halpert", email: "jim@dundermifflin.com", password: random_password},
@@ -26,7 +34,12 @@ user_seeds.each do |user_seed|
   user = User.create(first_name: user_seed[:first_name], last_name: user_seed[:last_name], email: user_seed[:email], password: user_seed[:password], password_confirmation: user_seed[:password])
 end
 
+puts "Creating Organizations"
 40.times do
-  puts "Creating Organizations"
   org = Organization.create(name: Faker::Company.name, description: Faker::Company.catch_phrase)
+end
+
+puts "Creating Memberships"
+60.times do
+  membership = Membership.create(organization_id: random_org_id, user_id: random_user_id)
 end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :membership do
+    organization_id { nil }
+    user_id { nil }
+  end
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe Membership, type: :model do
     user.destroy
     expect(org.memberships.pluck(:id)).to_not include membership.id
   end
+
+  context "when existing" do
+    it "rejects new membership of existing user/org id pairs" do
+      membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
+      membership2 = FactoryBot.build(:membership, organization_id: org.id, user_id: user.id)
+      membership2.valid?
+
+      expect(membership2.errors[:organization_id]).to eq ["already has a membership with this user."]
+    end
+  end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Membership, type: :model do
+  let(:org) { FactoryBot.create(:organization) }
+  let(:user) { FactoryBot.create(:user) }
+
+  it "is valid with an organization_id and user_id" do
+    membership = FactoryBot.build(:membership, organization_id: org.id, user_id: user.id)
+    expect(membership).to be_valid
+  end
+
+  it "is invalid without an organization_id" do
+    membership = FactoryBot.build(:membership, user_id: user)
+    expect(membership).to_not be_valid
+  end
+
+  it "is invalid without a user_id" do
+    membership = FactoryBot.build(:membership, organization_id: org)
+    expect(membership).to_not be_valid
+  end
+
+  it "is destroyed when the organization is destroyed" do
+    membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
+
+    expect(user.memberships.pluck(:id)).to include membership.id
+    org.destroy
+    expect(user.memberships.pluck(:id)).to_not include membership.id
+  end
+
+  it "is destroyed when the user is destroyed" do
+    membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
+
+    expect(org.memberships.pluck(:id)).to include membership.id
+    user.destroy
+    expect(org.memberships.pluck(:id)).to_not include membership.id
+  end
+end


### PR DESCRIPTION
This adds the ability to create Memberships between Organizations and Users.  If an organization and user already have a membership, a new one cannot be created.

With this addition comes multiple ways to obtain association/membership data:
**.memberships** (both models)
**.users** (on an Organization object)
**.organizations** (on a User object)