### PR TITLE
Final tweaks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,8 +80,13 @@ hr {
   margin:  0px 5px;
 }
 
-/* Mobile */
+ol {
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+}
 
+/* Mobile */
 .card {
   width: 100%;
   margin: 10px 10px;

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,7 +3,7 @@ class OrganizationsController < ApplicationController
 
   def index
     @search_name = params[:name]
-    @organizations = Organization.order(:name)
+    @organizations = Organization.all
     @organizations = @organizations.search_by_name(@search_name) if @search_name.present?
     @search_result_count = @organizations.count
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,5 +4,5 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true
 
-  scope :search_by_name, -> (name) { where("lower(name) LIKE ?", "%#{name}%") }
+  scope :search_by_name, -> (name) { where("lower(name) LIKE ?", "%#{name}%").order(:name) }
 end

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -1,5 +1,5 @@
-<div class="card">
+<li class="card">
   <h1 class="card-title"><%= link_to organization.name, organization %></h1>
   <hr>
   <p class="card-description"><%= organization.description %></p>
-</div>
+</li>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -4,8 +4,7 @@
   <div class="search-box-wrapper">
     <%= form_with url: organizations_path, skip_enforcing_utf8: true, method: :get, local: true do |f| %>
       <%= f.label :name, class: "hidden-label" %>
-      <%= f.text_field :name, id: :name, class: "search-input", placeholder: "Find Organization", value: params[:name], autofocus: true
-      %>
+      <%= f.text_field :name, id: :name, class: "search-input", placeholder: "Find Organization", value: params[:name] %>
       <%= f.submit "Search", class: "button", name: nil %>
     <% end %>
   </div>
@@ -17,5 +16,9 @@
     <%= button_to "Clear Search", organizations_path, class: "button", method: :get %>
   <% end %>
 
-  <%= render @organizations %>
+  <main>
+    <ol class="wrapper">
+      <%= render @organizations %>
+    </ol>
+  </main>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, @organization.name) %>
 
-<div class="wrapper">
+<main class="wrapper">
   <div class="card">
     <h1 class="card-title card-title-center"><%= @organization.name %></h1>
     <hr>
@@ -13,5 +13,5 @@
       <p class="card-description"><%= member.full_name %>: <%= member.email %></p>
     <% end %>
   </div>
-  <%= link_to "Back to All Organizations", organizations_path %>
-</div>
+  <%= link_to "Back to All Organizations", organizations_path, class: "button" %>
+</main>

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -3,45 +3,52 @@ require 'rails_helper'
 RSpec.describe Membership, type: :model do
   let(:org) { FactoryBot.create(:organization) }
   let(:user) { FactoryBot.create(:user) }
+  let(:build_membership) { FactoryBot.build(:membership, organization_id: org.id, user_id: user.id) }
+  let(:membership) { FactoryBot.create(:membership, organization_id: org.id, user_id: user.id) }
 
-  it "is valid with an organization_id and user_id" do
-    membership = FactoryBot.build(:membership, organization_id: org.id, user_id: user.id)
-    expect(membership).to be_valid
-  end
+  context "validations" do
+    it "is valid with an organization_id and user_id" do
+      expect(build_membership).to be_valid
+    end
 
-  it "is invalid without an organization_id" do
-    membership = FactoryBot.build(:membership, user_id: user)
-    expect(membership).to_not be_valid
-  end
+    it "is invalid without an organization_id" do
+      membership = FactoryBot.build(:membership, user_id: user)
+      expect(membership).to_not be_valid
+    end
 
-  it "is invalid without a user_id" do
-    membership = FactoryBot.build(:membership, organization_id: org)
-    expect(membership).to_not be_valid
-  end
-
-  it "is destroyed when the organization is destroyed" do
-    membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
-
-    expect(user.memberships.pluck(:id)).to include membership.id
-    org.destroy
-    expect(user.memberships.pluck(:id)).to_not include membership.id
-  end
-
-  it "is destroyed when the user is destroyed" do
-    membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
-
-    expect(org.memberships.pluck(:id)).to include membership.id
-    user.destroy
-    expect(org.memberships.pluck(:id)).to_not include membership.id
-  end
-
-  context "when existing" do
-    it "rejects new membership of existing user/org id pairs" do
-      membership = FactoryBot.create(:membership, organization_id: org.id, user_id: user.id)
-      membership2 = FactoryBot.build(:membership, organization_id: org.id, user_id: user.id)
-      membership2.valid?
-
-      expect(membership2.errors[:organization_id]).to eq ["already has a membership with this user."]
+    it "is invalid without a user_id" do
+      membership = FactoryBot.build(:membership, organization_id: org)
+      expect(membership).to_not be_valid
     end
   end
+
+  context "creation" do
+    it "rejects new membership of existing user/org id pairs" do
+      membership
+      build_membership.valid?
+
+      expect(build_membership.errors[:organization_id]).to eq ["already has a membership with this user."]
+    end
+  end
+
+  context "destruction" do
+    it "is destroyed when the organization is destroyed" do
+      membership
+
+      expect(user.memberships.pluck(:id)).to include membership.id
+      org.destroy
+      expect(user.memberships.pluck(:id)).to_not include membership.id
+      expect { membership.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "is destroyed when the user is destroyed" do
+      membership
+
+      expect(org.memberships.pluck(:id)).to include membership.id
+      user.destroy
+      expect(org.memberships.pluck(:id)).to_not include membership.id
+      expect { membership.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,44 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do
-  it "is valid with a name and description" do
-    organization = FactoryBot.build(:organization)
-    expect(organization).to be_valid
+
+  context "validations" do
+    it "is valid with a name and description" do
+      organization = FactoryBot.build(:organization)
+      expect(organization).to be_valid
+    end
+
+    it "is invalid without a first_name" do
+      organization = FactoryBot.build(:organization, name: nil)
+      organization.valid?
+
+      expect(organization.errors[:name]).to include("can't be blank")
+    end
   end
 
-  it "is invalid without a first_name" do
-    organization = FactoryBot.build(:organization, name: nil)
-    organization.valid?
-
-    expect(organization.errors[:name]).to include("can't be blank")
-  end
-
-  context "Searching" do
+  context "searching" do
     let!(:organization_1) { FactoryBot.create(:organization, name: "Test LLC Org", id: 1) }
     let!(:organization_2) { FactoryBot.create(:organization, name: "Potato Org", id: 2) }
     let!(:organization_3) { FactoryBot.create(:organization, name: "An LLC Organization", id: 3) }
     let!(:organization_4) { FactoryBot.create(:organization, name: "The Office", id: 4) }
     let!(:organization_5) { FactoryBot.create(:organization, name: "Swell Corgis", id: 5) }
-    let(:organizations) { Organization.order(:name) }
+    let(:organizations)   { Organization.all }
 
     it "returns all organizations on empty search" do
-      filtered = Organization.search_by_name("").count
-      expect(filtered).to eq Organization.count
+      expect(organizations.search_by_name("").count).to eq organizations.count
     end
 
     it "returns expected number of organizations when matching results found" do
-      filtered = Organization.search_by_name("LL").count
-      expect(filtered).to eq 3
+      expect(organizations.search_by_name("LL").count).to eq 3
     end
 
     it "returns expected number organizations with lowercase input" do
-      filtered = Organization.search_by_name("ll").count
-      expect(filtered).to eq 3
+      expect(organizations.search_by_name("ll").count).to eq 3
     end
 
     it "returns expected number organizations with mixed case input" do
-      filtered = Organization.search_by_name("lL").count
-      expect(filtered).to eq 3
+      expect(organizations.search_by_name("lL").count).to eq 3
     end
 
     it "returns expected organizations in alphabetical order" do


### PR DESCRIPTION
- Initially made all orgs and all search results ordered by name, but this changes it to only apply order on search results to be closer to the task instructions

- Wrapped Organization index cards in an ordered list (realized I might have assumed a general ordered list by name when you want a literal ordered list. Honestly unsure)

- Various Organization and Membership unit test changes.